### PR TITLE
Ensure hm_platform_xray_errors is an array

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -11,6 +11,8 @@ namespace HM\Platform\XRay;
 use function HM\Platform\get_aws_sdk;
 use Exception;
 
+$GLOBALS['hm_platform_xray_errors'] = [];
+
 add_action( 'shutdown', __NAMESPACE__ . '\\on_shutdown', 99 );
 set_error_handler( __NAMESPACE__ . '\\error_handler' );
 


### PR DESCRIPTION
We're getting errors from the `array_diff()` in `get_trace()`. When there are no errors, `$hm_platform_xray_errors` is not defined, which causes `wp_list_pluck` to return `null`. Running `array_diff` on this causes a warning.