### PR TITLE
overload wpdb::get_caller()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.0.3 - 2018-10-23
+
+- Use local declaration of wp_debug_backtrace_summary
+
 ## 1.0.2 - 2018-10-12
 
 - Track Remote Requests made via the WordPress HTTP API.

--- a/inc/class-db.php
+++ b/inc/class-db.php
@@ -15,10 +15,6 @@ class DB extends wpdb {
 	}
 
 	public function get_caller() {
-		if ( function_exists( 'wp_debug_backtrace_summary' ) ) {
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_wp_debug_backtrace_summary
-			return wp_debug_backtrace_summary( __CLASS__ );
-		}
 		return $this->wp_debug_backtrace_summary( __CLASS__ );
 	}
 

--- a/inc/class-db.php
+++ b/inc/class-db.php
@@ -44,7 +44,7 @@ class DB extends wpdb {
 			$trace = debug_backtrace();
 		}
 
-		$caller = [];
+		$caller      = [];
 		$check_class = ! is_null( $ignore_class );
 		$skip_frames++; // skip this function
 

--- a/inc/class-db.php
+++ b/inc/class-db.php
@@ -13,4 +13,62 @@ class DB extends wpdb {
 		}
 		return $result;
 	}
+
+	public function get_caller() {
+		if ( function_exists( 'wp_debug_backtrace_summary' ) ) {
+			return wp_debug_backtrace_summary( __CLASS__ );
+		}
+		return $this->wp_debug_backtrace_summary( __CLASS__ );
+	}
+
+	/**
+	* Return a comma-separated string of functions that have been called to get
+	* to the current point in code.
+	*
+	* @since 3.4.0
+	*
+	* @see https://core.trac.wordpress.org/ticket/19589
+	*
+	* @param string $ignore_class Optional. A class to ignore all function calls within - useful
+	*                             when you want to just give info about the callee. Default null.
+	* @param int    $skip_frames  Optional. A number of stack frames to skip - useful for unwinding
+	*                             back to the source of the issue. Default 0.
+	* @param bool   $pretty       Optional. Whether or not you want a comma separated string or raw
+	*                             array returned. Default true.
+	* @return string|array Either a string containing a reversed comma separated trace or an array
+	*                      of individual calls.
+	*/
+	function wp_debug_backtrace_summary( $ignore_class = null, $skip_frames = 0, $pretty = true ) {
+		if ( version_compare( PHP_VERSION, '5.2.5', '>=' ) )
+			$trace = debug_backtrace( false );
+		else
+			$trace = debug_backtrace();
+
+		$caller = array();
+		$check_class = ! is_null( $ignore_class );
+		$skip_frames++; // skip this function
+
+		foreach ( $trace as $call ) {
+			if ( $skip_frames > 0 ) {
+				$skip_frames--;
+			} elseif ( isset( $call['class'] ) ) {
+				if ( $check_class && $ignore_class == $call['class'] )
+					continue; // Filter out calls
+
+				$caller[] = "{$call['class']}{$call['type']}{$call['function']}";
+			} else {
+				if ( in_array( $call['function'], array( 'do_action', 'apply_filters' ) ) ) {
+					$caller[] = "{$call['function']}('{$call['args'][0]}')";
+				} elseif ( in_array( $call['function'], array( 'include', 'include_once', 'require', 'require_once' ) ) ) {
+					$caller[] = $call['function'] . "('" . str_replace( array( WP_CONTENT_DIR, ABSPATH ) , '', $call['args'][0] ) . "')";
+				} else {
+					$caller[] = $call['function'];
+				}
+			}
+		}
+		if ( $pretty )
+			return join( ', ', array_reverse( $caller ) );
+		else
+			return $caller;
+	}
 }

--- a/inc/class-db.php
+++ b/inc/class-db.php
@@ -16,6 +16,7 @@ class DB extends wpdb {
 
 	public function get_caller() {
 		if ( function_exists( 'wp_debug_backtrace_summary' ) ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_wp_debug_backtrace_summary
 			return wp_debug_backtrace_summary( __CLASS__ );
 		}
 		return $this->wp_debug_backtrace_summary( __CLASS__ );
@@ -39,12 +40,15 @@ class DB extends wpdb {
 	*                      of individual calls.
 	*/
 	function wp_debug_backtrace_summary( $ignore_class = null, $skip_frames = 0, $pretty = true ) {
-		if ( version_compare( PHP_VERSION, '5.2.5', '>=' ) )
+		if ( version_compare( PHP_VERSION, '5.2.5', '>=' ) ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace
 			$trace = debug_backtrace( false );
-		else
+		} else {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace
 			$trace = debug_backtrace();
+		}
 
-		$caller = array();
+		$caller = [];
 		$check_class = ! is_null( $ignore_class );
 		$skip_frames++; // skip this function
 
@@ -52,23 +56,25 @@ class DB extends wpdb {
 			if ( $skip_frames > 0 ) {
 				$skip_frames--;
 			} elseif ( isset( $call['class'] ) ) {
-				if ( $check_class && $ignore_class == $call['class'] )
+				if ( $check_class && $ignore_class === $call['class'] ) {
 					continue; // Filter out calls
+				}
 
 				$caller[] = "{$call['class']}{$call['type']}{$call['function']}";
 			} else {
-				if ( in_array( $call['function'], array( 'do_action', 'apply_filters' ) ) ) {
+				if ( in_array( $call['function'], [ 'do_action', 'apply_filters' ], true ) ) {
 					$caller[] = "{$call['function']}('{$call['args'][0]}')";
-				} elseif ( in_array( $call['function'], array( 'include', 'include_once', 'require', 'require_once' ) ) ) {
-					$caller[] = $call['function'] . "('" . str_replace( array( WP_CONTENT_DIR, ABSPATH ) , '', $call['args'][0] ) . "')";
+				} elseif ( in_array( $call['function'], [ 'include', 'include_once', 'require', 'require_once' ], true ) ) {
+					$caller[] = $call['function'] . "('" . str_replace( [ WP_CONTENT_DIR, ABSPATH ], '', $call['args'][0] ) . "')";
 				} else {
 					$caller[] = $call['function'];
 				}
 			}
 		}
-		if ( $pretty )
+		if ( $pretty ) {
 			return join( ', ', array_reverse( $caller ) );
-		else
+		} else {
 			return $caller;
+		}
 	}
 }

--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
  * Plugin Name: AWS X-Ray
  * Description: HM Platform plugin for sending data to AWS X-Ray
  * Author: Human made
- * Version: 1.0.2
+ * Version: 1.0.3
  */
 
 namespace HM\Platform\XRay;


### PR DESCRIPTION
If there's ever an error that occurs in a wpdb query and `wp-includes/functions.php` hasn't been loaded yet (eg when using hm-platform), `wp_debug_backtrace_summary` won't be available and will cause fatal errors. This overloads the `wpdb::get_caller()` method in order to redirect to a local copy `wp_debug_backtrace_summary` when the function is not available yet.