### PR TITLE
Filter use of fastcgi_finish_request

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -44,7 +44,12 @@ function bootstrap() {
  * Shutdown callback to process the trace once everything has finished.
  */
 function on_shutdown() {
-	if ( function_exists( 'fastcgi_finish_request' ) ) {
+	$use_fastcgi_finish_request = function_exists( 'fastcgi_finish_request' );
+	if ( function_exists( 'apply_filters' ) ) {
+		$use_fastcgi_finish_request = apply_filters( 'aws_xray.use_fastcgi_finish_request', $use_fastcgi_finish_request );
+	}
+
+	if ( $use_fastcgi_finish_request ) {
 		fastcgi_finish_request();
 	}
 


### PR DESCRIPTION
This is a filter to allow plugins to override the use of fastcgi_finish_request.

`fastcgi_finish_request` can cause compat issues with other plugins that hook in on `shutdown` and output data, so we might not always want to close the connection on the first shutdown function call. 