### PR TITLE
Check if do_action exists.

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -195,7 +195,10 @@ function send_trace_to_aws( array $trace ) {
  * @param array $trace
  */
 function send_trace_to_daemon( array $trace ) {
-	do_action( 'aws_xray.send_trace_to_daemon', $trace );
+
+	if ( function_exists( 'do_action' ) ) {
+		do_action( 'aws_xray.send_trace_to_daemon', $trace );
+	}
 
 	$header = '{"format": "json", "version": 1}';
 	$messages = get_flattened_segments_from_trace( $trace );


### PR DESCRIPTION
`namespace.php` can be included very early, which means `do_action` may not be available.