### PR TITLE
Allow backslash in names

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -398,7 +398,7 @@ function get_xhprof_xray_trace() : array {
 
 function get_xray_segmant_for_xhprof_trace( $item ) : array {
 	return [
-		'name'        => preg_replace( '~[^\\w\\s_\\.:/%&#=+\\-@]~u', '', $item->name ),
+		'name'        => preg_replace( '~[^\\w\\s_\\.:/%&#=+\\\\\\-@]~u', '', $item->name ),
 		'subsegments' => array_map( __FUNCTION__, $item->children ),
 		'id'          => bin2hex( random_bytes( 8 ) ),
 		'start_time'  => $item->start_time,

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -398,7 +398,7 @@ function get_xhprof_xray_trace() : array {
 
 function get_xray_segmant_for_xhprof_trace( $item ) : array {
 	return [
-		'name'        => preg_replace( '~[^\w\s_\.:/%&#=+\-@]~u', '', $item->name ),
+		'name'        => preg_replace( '~[^\\w\\s_\\.:/%&#=+\\-@]~u', '', $item->name ),
 		'subsegments' => array_map( __FUNCTION__, $item->children ),
 		'id'          => bin2hex( random_bytes( 8 ) ),
 		'start_time'  => $item->start_time,


### PR DESCRIPTION
The allowed characters in the segment name sanitising code appears to have been copy and pasted from the [AWS documentation](https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html#api-segmentdocuments-fields). The backslashes here are escaping the character after them from PHP's perspective, but also need escaping from the regex engine. In most cases, this has no effect (because redundantly escaping a character doesn't do anything), but the backslash itself needs double-escaping.

This gives the following at the end of the regex:
```
+\\\\\\-@
 |  |||
 |  |\+----- Escape the range operator (-) to treat as a dash
 |  |
 \--+------- Escape the backslash from PHP, and from the regex engine
```

Before, `Altis\bootstrap` -> `Altisbootstrap`
After, `Altis\bootstrap` -> `Altis\bootstrap`