### PR TITLE
Send end trace on early shutdown

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -30,7 +30,6 @@ function bootstrap() {
 		add_action( 'shutdown', __NAMESPACE__ . '\\on_shutdown_action' );
 	}
 
-
 	// As well as using the shutdown action, we register as "direct" shutdown function in the event
 	// that the 'shutdown' action is never registered (such as requests that hit advanced-cache.php),
 	// of is the add_action API is not yet available.
@@ -96,8 +95,8 @@ function on_shutdown() {
 
 	// It's possible the script is shutting down before register_shutdown_function( 'shutdown_action_hook' )
 	// has been called by WordPress. There's no way to check if this callback has been registered, so we use a heuristic that
-	// default-filters.php has not been loaded, which happens just before WordPress calls register_shutdown_function.
-	if ( has_action( 'wp_scheduled_delete', 'wp_scheduled_delete' ) === false ) {
+	// get_locale() has been defined, which happens just after WordPress calls register_shutdown_function.
+	if ( ! function_exists( 'get_locale' ) ) {
 		on_shutdown_action();
 		return;
 	}

--- a/inc/query_monitor/namespace.php
+++ b/inc/query_monitor/namespace.php
@@ -28,8 +28,8 @@ function register_qm_collector( array $collectors ) : array {
 	add_filter( 'aws_xray.use_fastcgi_finish_request', '__return_false' );
 
 	// Make sure the XRay shutdown function runs before the Query Monitor one.
-	remove_filter( 'shutdown', 'HM\\Platform\\XRay\\on_shutdown' );
-	add_filter( 'shutdown', 'HM\\Platform\\XRay\\on_shutdown', -1 );
+	remove_filter( 'shutdown', 'HM\\Platform\\XRay\\on_shutdown_action' );
+	add_filter( 'shutdown', 'HM\\Platform\\XRay\\on_shutdown_action', -1 );
 
 	require_once __DIR__ . '/class-collector.php';
 	$collectors['aws-xray'] = new Collector();


### PR DESCRIPTION
Currently if the script execution ends before the WordPress shutdown handler has been set up, we don't sent the end trace. This is a problem because Batcache (or any advanced-cache.php) HIT will be before the shutdown handler for WordPress has been set up.

We have to add our own shutdown handler in all cases, and only use it where appropriate.