### PR TITLE
Move the name() method to the output html class.

### DIFF
--- a/inc/query_monitor/class-collector.php
+++ b/inc/query_monitor/class-collector.php
@@ -15,10 +15,6 @@ class Collector extends QM_Collector {
 		$this->trace_sent_to_daemon( get_in_progress_trace() );
 	}
 
-	public function name() {
-		return __( 'AWS X-Ray', 'aws-xray' );
-	}
-
 	/**
 	 * Track all traces in memory that are send to the X Ray daemon.
 	 *

--- a/inc/query_monitor/class-output-html.php
+++ b/inc/query_monitor/class-output-html.php
@@ -13,6 +13,10 @@ class Output_Html extends QM_Output_Html {
 		add_filter( 'qm/output/panel_menus', [ $this, 'panel_menu' ], 40 );
 	}
 
+	public function name() {
+		return __( 'AWS X-Ray', 'aws-xray' );
+	}
+
 	public function output() {
 		?>
 		<?php $this->before_tabular_output(); ?>


### PR DESCRIPTION
This gets rid of the deprecation warning thrown by QM 5.3+.