### PR TITLE
Handle missing x-amz-target header

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -651,8 +651,8 @@ function on_aws_guzzle_request_stats( TransferStats $stats ) {
 			],
 		],
 		'aws'          => [
-			'request_id'  => $request_id ? $request_id[0] : null,
-			'operation'   => explode( '.', $stats->getRequest()->getHeader( 'x-amz-target' )[0] )[1],
+			'request_id'  => $request_id[0] ?? null,
+			'operation'   => explode( '.', $stats->getRequest()->getHeader( 'x-amz-target' )[0] ?? 'xray.amz-unknown-target' )[1],
 		],
 		'in_progress'  => false,
 		'fault'        => $code > 499,


### PR DESCRIPTION
In some cases - particularly on local environments `$request_id` can be truthy but empty, or without offset 0 being set, additionally the `x-amz-target` header isn't always set in requests to S3. This update ensures both cases don't cause warnings to be output but rather falls back to reasonable defaults.

A missing `x-amz-target` header will give `amz-unknown-target` as the value if it's not set.