### PR TITLE
Truncate Long SQL Query

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -185,7 +185,7 @@ function trace_requests_request( $url, $headers, $data, $method, $options ) {
 }
 
 function trace_wpdb_query( string $query, float $start_time, float $end_time, $errored, $host = null ) {
-	// Truncate long query to ensure not exceed max limit.
+	// Truncate long query to ensure it does not exceed max limit.
 	$query = truncate_query( $query );
 
 	$trace = [
@@ -806,15 +806,15 @@ function redact_metadata( $metadata ) {
 }
 
 /**
- * Truncate sql query to given max_size.
+ * Truncate sql query to given maximum size.
  *
  * @param string $query       SQL Query to truncate.
- * @param int    $max_size    Maximum size, default 5KB.
+ * @param int    $max_size    Maximum size in bytes, default 5KB.
  * @param string $replacement String replacement.
  *
  * @return string
  */
-function truncate_query( string $query, int $max_size = 5 * 1024, string $replacement = '…' ): string {
+function truncate_query( string $query, int $max_size = 5 * 1024, string $replacement = '…' ) : string {
 	if ( mb_strlen( $query ) < $max_size ) {
 		return $query;
 	}

--- a/tests/class-test-truncate-query.php
+++ b/tests/class-test-truncate-query.php
@@ -1,14 +1,21 @@
 <?php
+/**
+ * Test coverage for truncate_query function
+ */
 
-namespace HM\Platform\XRay; // @codingStandardsIgnoreLine inc directory ok.
+namespace HM\Platform\XRay;
+// @codingStandardsIgnoreLine inc directory ok.
 
 use PHPUnit\Framework\TestCase;
 
 class Test_Truncate_Query extends TestCase {
 
+	/**
+	 * Test truncate long query
+	 */
 	function test_truncate_long_query() {
-		$max_size = 5 * 1024;
-		$long_text = $this->generate_random_string( $max_size * 2 );
+		$max_size         = 5 * 1024;
+		$long_text        = $this->generate_random_string( $max_size * 2 );
 		$super_long_query = sprintf(
 			"INSERT INTO wp_postmeta(`post_id`,`meta_key`,`meta_values`) values('123', 'long_meta', '%s')",
 			$long_text
@@ -16,22 +23,25 @@ class Test_Truncate_Query extends TestCase {
 
 		$redacted = truncate_query( $super_long_query, $max_size );
 
-		$this->assertTrue( mb_strlen( $redacted ) < $max_size );
+		$this->assertTrue( mb_strlen( $redacted ) <= $max_size );
 	}
 
-	// Test to s
+	/**
+	 * Test truncate short query
+	 */
 	function test_truncate_short_query() {
-		$max_size = 5 * 1024;
+		$max_size  = 5 * 1024;
 		$long_text = $this->generate_random_string( $max_size / 2 );
-		$query = sprintf(
+		$query     = sprintf(
 			"INSERT INTO wp_postmeta(`post_id`,`meta_key`,`meta_values`) values('123', 'long_meta', '%s')",
 			$long_text
 		);
 
 		$redacted = truncate_query( $query, $max_size );
 
-		$this->assertTrue( mb_strlen( $redacted ) < $max_size );
+		$this->assertTrue( mb_strlen( $redacted ) <= $max_size );
 		$this->assertEquals( $query, $redacted );
+
 	}
 
 	/**

--- a/tests/class-test-truncate-query.php
+++ b/tests/class-test-truncate-query.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace HM\Platform\XRay; // @codingStandardsIgnoreLine inc directory ok.
+
+use PHPUnit\Framework\TestCase;
+
+class Test_Truncate_Query extends TestCase {
+
+	function test_truncate_long_query() {
+		$max_size = 5 * 1024;
+		$long_text = $this->generate_random_string( $max_size * 2 );
+		$super_long_query = sprintf(
+			"INSERT INTO wp_postmeta(`post_id`,`meta_key`,`meta_values`) values('123', 'long_meta', '%s')",
+			$long_text
+		);
+
+		$redacted = truncate_query( $super_long_query, $max_size );
+
+		$this->assertTrue( mb_strlen( $redacted ) < $max_size );
+	}
+
+	// Test to s
+	function test_truncate_short_query() {
+		$max_size = 5 * 1024;
+		$long_text = $this->generate_random_string( $max_size / 2 );
+		$query = sprintf(
+			"INSERT INTO wp_postmeta(`post_id`,`meta_key`,`meta_values`) values('123', 'long_meta', '%s')",
+			$long_text
+		);
+
+		$redacted = truncate_query( $query, $max_size );
+
+		$this->assertTrue( mb_strlen( $redacted ) < $max_size );
+		$this->assertEquals( $query, $redacted );
+	}
+
+	/**
+	 * Generate random string of given length
+	 *
+	 * @param int $length Length of string.
+	 *
+	 * @return false|string
+	 */
+	function generate_random_string( int $length ): string {
+		$all_chars   = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+		$long_string = str_shuffle( str_repeat( $all_chars, ceil( $length / strlen( $all_chars ) ) ) );
+
+		return substr( $long_string, 0, $length );
+	}
+}

--- a/tests/class-test-truncate-query.php
+++ b/tests/class-test-truncate-query.php
@@ -4,10 +4,14 @@
  */
 
 namespace HM\Platform\XRay;
-// @codingStandardsIgnoreLine inc directory ok.
 
 use PHPUnit\Framework\TestCase;
 
+/**
+ * Class Test_Truncate_Query
+ *
+ * @package HM\Platform\XRay
+ */
 class Test_Truncate_Query extends TestCase {
 
 	/**


### PR DESCRIPTION
Fixed #74 

This PR is to ensure we truncate the long query to max 5KB. As this is enough for any accident analysis on XRay reporting. 