### PR TITLE
Fix timestamp calculations

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -517,11 +517,14 @@ function add_children_to_nodes( array $nodes, array $children, float $sample_tim
 	$last_node = $nodes ? $nodes[ count( $nodes ) - 1 ] : null;
 	$this_child = $children[0];
 
+	// If this item is the same as the previous, then the call was still in
+	// progress. Increase the existing node by one more sample duration.
 	if ( $last_node && $last_node->name === $this_child ) {
 		$node            = $last_node;
 		$node->value    += ( $sample_duration / 1000 );
 		$node->end_time += $sample_duration;
 	} else {
+		// Not the same, so add a new node.
 		$nodes[] = $node = (object) [  // @codingStandardsIgnoreLine
 			'name'       => $this_child,
 			'value'      => $sample_duration / 1000,

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -479,7 +479,7 @@ function get_xhprof_trace() : array {
 	// Trim to stack to have a theoretical maximum, essentially reducing the resolution.
 	if ( count( $stack ) > $max_frames ) {
 		$pluck_every_n = ceil( count( $stack ) / $max_frames );
-		$sample_interval = ceil( $sample_interval * ( count( $stack ) / $max_frames ) );
+		$sample_interval = ceil( $sample_interval * $pluck_every_n );
 
 		$stack = array_filter(
 			$stack, function ( $value ) use ( $pluck_every_n ) : bool {


### PR DESCRIPTION
Fixes https://github.com/humanmade/product-dev/issues/851, see 6adf8ca4816c27bcc3a471aa5c28ac661e729731 for explanation of the problem:

> In cases where the rounded figure differed by a large amount, this lead
> to a large discrepency in the timestamps being calculated.
>
> For example, if there are 1001 frames, we take every second item
> ($pluck_every_n = 2). However, we calculate the duration as $original *
> ( 1001 / 1000 ), whereas by halving the number of frames, we actually
> need to double the duration.
>
> Using the same variable corrects for this inaccuracy and ensures
> consistency across the calculation.