### PR TITLE
Fix PHP 8 Fatal error in error handler code

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -79,7 +79,7 @@ function on_shutdown_action() {
 	// Check if we were shut down by an error.
 	$last_error = error_get_last();
 	if ( $last_error ) {
-		call_user_func_array( __NAMESPACE__ . '\\error_handler', $last_error );
+		call_user_func_array( __NAMESPACE__ . '\\error_handler', array_values( $last_error ) );
 	}
 
 	$profile = get_xray_profile();


### PR DESCRIPTION
With PHP 8 and named arguments, passing an associative array to `call_user_func_array` will throw a Fatal error in case the array keys do not match the parameter names.

<details><summary><strong>Error Log</strong></summary><pre><code>PHP Fatal error:  Uncaught Error: Unknown named parameter $type in /usr/src/app/vendor/humanmade/aws-xray/inc/namespace.php:82

Stack trace:
#0 /usr/src/app/vendor/humanmade/aws-xray/inc/namespace.php(82): call_user_func_array('HM\\Platform\\XRa...', Array)
#1 /usr/src/app/wordpress/wp-includes/class-wp-hook.php(307): HM\Platform\XRay\on_shutdown_action('')
#2 /usr/src/app/wordpress/wp-includes/class-wp-hook.php(331): WP_Hook->apply_filters('', Array)
#3 /usr/src/app/wordpress/wp-includes/plugin.php(474): WP_Hook->do_action(Array)
#4 /usr/src/app/wordpress/wp-includes/load.php(1100): do_action('shutdown')
#5 [internal function]: shutdown_action_hook()
#6 {main}
  thrown in /usr/src/app/vendor/humanmade/aws-xray/inc/namespace.php on line 82
</code></pre></details>

This PR fixes one such instance by ensuring that only the (unnamed) values are passed.

---

Minimal examples to see the issue:
- **Yo:** https://3v4l.org/4os7g#v8.0.22
- **No:** https://3v4l.org/Ovvhu#v8.0.22

This is the fix in this PR:
- **Yeah:** https://3v4l.org/qlr6v#v8.0.22