### PR TITLE
Trim leading whitespace and brackets before detecting query type

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -147,7 +147,7 @@ function error_handler( int $errno, string $errstr, string $errfile = null, int 
  */
 function filter_mysql_query( $query ) {
 	// Don't add Trace ID to SELECT queries as they will MISS in the MysQL query cache.
-	if ( stripos( trim( $query ), 'SELECT' ) === 0 ) {
+	if ( stripos( ltrim( $query, ' \t\n\r\0\x0B(' ), 'SELECT' ) === 0 ) {
 		return $query;
 	}
 	$query .= ' # Trace ID: ' . get_root_trace_id();


### PR DESCRIPTION
The `filter_mysql_query()` method adds a `# Trace ID:` comment to the end of non-SELECT queries to aid debugging slow queries. Some queries include other characters before the `SELECT` clause and therefore the trace ID comment still gets added to these.

Example query from MultilingualPress:

```sql
(SELECT DISTINCT site_1 AS site_id
FROM wp_mlp_site_relations
WHERE site_2 = 6)
UNION (SELECT DISTINCT site_2
FROM wp_mlp_site_relations
WHERE site_1 = 6)
ORDER BY site_id ASC # Trace ID: 1-63078aa8-43fb2162947f5d5e915ab956
```

The Query Monitor plugin strips more than just whitespace from the start of the SQL before determining its type, so the same can be done here.

Ref: https://github.com/johnbillion/query-monitor/blob/9a7600f3990710807c300079ad286c445f69fd83/classes/Util.php#L500-L502