### PR TITLE
Flamegraph improvements

### DIFF
--- a/assets/flamegraph.js
+++ b/assets/flamegraph.js
@@ -148,9 +148,9 @@ function flameGraph() {
 			name = name.split( '(' )[0]; // drop extra info
 			vector = generateHash( name );
 		}
-		let r = 200 + Math.round( 55 * vector );
-		let g = 0 + Math.round( 230 * ( 1 - vector ) );
-		let b = 0 + Math.round( 55 * ( 1 - vector ) );
+		let r = 50 + Math.round(60 * vector);
+		let g = 165 + Math.round(55 * vector);
+		let b = g;
 		return 'rgb(' + r + ',' + g + ',' + b + ')';
 	}
 
@@ -361,7 +361,7 @@ function flameGraph() {
 				.select( 'div' )
 				.attr( 'class', 'd3-flame-graph-label' )
 				.style( 'display', function ( d ) {
-					return width( d ) < 35 ? 'none' : 'block';
+					return 'block';
 				} )
 				.transition()
 				.delay( transitionDuration )
@@ -624,8 +624,10 @@ jQuery( document ).ready( function() {
 		var data = segmentToItem( JSON.parse( el.innerHTML ) );
 		el.innerHTML = '';
 		var flamegraph = flameGraph()
-			.width( 940 )
-			.cellHeight( 18 );
+			.width( Math.max( 940, jQuery('#qm-aws-xray-flamegraph').width() ) )
+			.cellHeight( 20 )
+			.transitionDuration( 250 )
+			.reversed( true );
 
 		d3.select( el )
 			.datum( data )

--- a/inc/query_monitor/class-output-flamegraph-html.php
+++ b/inc/query_monitor/class-output-flamegraph-html.php
@@ -49,6 +49,30 @@ class Output_Flamegraph_Html extends QM_Output_Html {
 				<?php endif ?>
 			</h2>
 		</caption>
+		<style>
+			.aws-xray-flamegraph {
+				width: 100%;
+			}
+
+			.d3-flame-graph rect {
+				stroke: #fff;
+			}
+
+			.d3-flame-graph foreignObject {
+				cursor: pointer;
+			}
+
+			.d3-flame-graph foreignObject:hover {
+				background-color: rgba( 255, 255, 255, 0.3 );
+			}
+
+			.d3-flame-graph foreignObject div {
+				margin: 0 3px;
+				color: #000;
+				font-size: 10px;
+				overflow: hidden;
+			}
+		</style>
 		<div class="aws-xray-flamegraph"><?php echo wp_json_encode( $xhprof ) ?></div>
 		<?php
 


### PR DESCRIPTION
This improves the flamegraph styling to aid usability and legibility, speed up the transition animation, increase information density, and bring it more inline with the styling in the Altis Dashboard.

## Before

<img width="1681" alt="" src="https://user-images.githubusercontent.com/208434/194888308-4d4d1528-6769-4856-ae5e-7d13956c5e9f.png">

## After

<img width="1680" alt="" src="https://user-images.githubusercontent.com/208434/194888445-e7a9187e-c996-4d1f-b0a6-138519c43d4a.png">

Fixes #78