### PR TITLE
Update sampling interval back to 5ms

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -11,7 +11,7 @@ use ExcimerProfiler;
 use GuzzleHttp\TransferStats;
 use WP_Object_Cache;
 
-const SAMPLE_INTERVAL = 0.05; // seconds.
+const SAMPLE_INTERVAL = 0.005; // seconds.
 
 /**
  * Set initial values and register handlers


### PR DESCRIPTION
Before we introduced excimer support, we were sampling at 5ms. PR to support excimer changed it to 50ms (see:
 https://github.com/humanmade/aws-xray/commit/8f8dcfed5b3cec2eef2ad2c157e34272448a193f#diff-a0f318343a79085d556c9f6050c1261041075f5129f00e908fce122d89e02febL24 )

This PR reverts back sampling interval to 5ms.

There's no notable change on the performance.

Making sure local xray is running:

```
my-project-13-xray  | 2023-01-31T13:01:01Z [Info] Initializing AWS X-Ray daemon 3.3.3
my-project-13-xray  | 2023-01-31T13:01:01Z [Info] Using buffer memory limit of 39 MB
my-project-13-xray  | 2023-01-31T13:01:01Z [Info] 624 segment buffers allocated
my-project-13-xray  | 2023-01-31T13:01:01Z [Info] Using region: us-east-1
my-project-13-xray  | 2023-01-31T13:01:06Z [Error] Get instance id metadata failed: RequestError: send request failed
my-project-13-xray  | caused by: Get "http://169.254.169.254/latest/meta-data/instance-id": dial tcp 169.254.169.254:80: connect: connection refused
my-project-13-xray  | 2023-01-31T13:01:06Z [Info] HTTP Proxy server using X-Ray Endpoint : https://xray.us-east-1.amazonaws.com
my-project-13-xray  | 2023-01-31T13:01:06Z [Info] Starting proxy http server on 0.0.0.0:2000
my-project-13-xray  | 2023-01-31T13:04:19Z [Info] Successfully sent batch of 1 segments (1.217 seconds)
---truncated---
```

Before 
```
Transactions:		         500 hits
Availability:		      100.00 %
Elapsed time:		      435.82 secs
Data transferred:	        3.68 MB
Response time:		        0.87 secs
Transaction rate:	        1.15 trans/sec
Throughput:		        0.01 MB/sec
Concurrency:		        1.00
Successful transactions:         500
Failed transactions:	           0
Longest transaction:	        3.54
Shortest transaction:	        0.52
```

After
```
Transactions:		         500 hits
Availability:		      100.00 %
Elapsed time:		      592.74 secs
Data transferred:	        3.68 MB
Response time:		        1.19 secs
Transaction rate:	        0.84 trans/sec
Throughput:		        0.01 MB/sec
Concurrency:		        1.00
Successful transactions:         500
Failed transactions:	           0
Longest transaction:	        5.33
Shortest transaction:	        0.58
```

https://github.com/humanmade/aws-xray/issues/86