### PR TITLE
Add `php://input` to trace metadata

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -395,10 +395,11 @@ function get_in_progress_trace() : array {
 		'in_progress' => true,
 	];
 	$metadata = [
-		'$_GET'     => $_GET,
-		'$_POST'    => $_POST,
-		'$_COOKIE'  => $_COOKIE,
-		'$_SERVER'  => $_SERVER,
+		'$_GET' => $_GET,
+		'$_POST' => $_POST,
+		'$_COOKIE' => $_COOKIE,
+		'$_SERVER' => $_SERVER,
+		'php://input' => file_get_contents( 'php://input' ),
 		'response' => [],
 	];
 	$trace['metadata'] = redact_metadata( $metadata );
@@ -468,14 +469,15 @@ function get_end_trace() : array {
 	];
 
 	$metadata = [
-		'$_GET'        => $_GET,
-		'$_POST'       => $_POST,
-		'$_COOKIE'     => $_COOKIE,
-		'$_SERVER'     => $_SERVER,
-		'response'     => [
+		'$_GET' => $_GET,
+		'$_POST' => $_POST,
+		'$_COOKIE' => $_COOKIE,
+		'$_SERVER' => $_SERVER,
+		'php://input'  => file_get_contents( 'php://input' ),
+		'response' => [
 			'headers' => headers_list(),
 		],
-		'stats'     => $stats,
+		'stats' => $stats,
 	];
 
 	$annotations = [


### PR DESCRIPTION
This lets us report on REST API body payloads as well as regular form data.