### PR TITLE
Fix the frame number in Excimer profile

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -554,8 +554,18 @@ function get_excimer_profile() : array {
 		if ( ! $call_stack ) {
 			continue;
 		}
+		// Format of callstack is `call1;call2 2` for e.g. 2 frames. This differs from XHProf,
+		// which will typically output a single frame per line.
 		$call_stack = explode( ';', trim( $call_stack, ';' ) );
-		$nodes = add_children_to_nodes( $nodes, $call_stack, (float) $time, $sample_interval );
+
+		// Split the last item into the frame count and replace the last item with the callstack without
+		// the frame count.
+		$last = $call_stack[ count( $call_stack ) - 1 ];
+		$last = explode( ' ', $last );
+		$call_stack[ count( $call_stack ) - 1 ] = $last[0];
+		$frame_count = $last[1] ?? 1;
+
+		$nodes = add_children_to_nodes( $nodes, $call_stack, (float) $time, $sample_interval * $frame_count );
 		$time += $sample_interval;
 	}
 


### PR DESCRIPTION
The excimer sample frames include the frame count at the end of the line, so we need to mulitply the duration for the frame by the frame count. At the moment very slow functions will ever be tracked as a single frame / duretion of the interval (5ms).
