### PR TITLE
Improve timings by using headers

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -383,7 +383,7 @@ function get_in_progress_trace() : array {
 		'name'       => defined( 'HM_ENV' ) ? HM_ENV : 'local',
 		'id'         => get_main_trace_id(),
 		'trace_id'   => get_root_trace_id(),
-		'start_time' => $hm_platform_xray_start_time,
+		'start_time' => (float) $_SERVER['REQUEST_TIME_FLOAT'] ?? $hm_platform_xray_start_time,
 		'service'    => [
 			'version' => defined( 'HM_DEPLOYMENT_REVISION' ) ? HM_DEPLOYMENT_REVISION : 'dev',
 		],
@@ -405,7 +405,9 @@ function get_in_progress_trace() : array {
 		'response' => [],
 	];
 	$trace['metadata'] = redact_metadata( $metadata );
-
+	$trace['annotations'] = [
+		'fpmQueueTime' => $_SERVER['REQUEST_TIME_FLOAT'] - $_SERVER['NGINX_REQUEST_TIME'],
+	];
 	return $trace;
 }
 
@@ -432,7 +434,7 @@ function get_end_trace() : array {
 		'name'       => defined( 'HM_ENV' ) ? HM_ENV : 'local',
 		'id'         => get_main_trace_id(),
 		'trace_id'   => get_root_trace_id(),
-		'start_time' => $hm_platform_xray_start_time,
+		'start_time' => (float) $_SERVER['REQUEST_TIME_FLOAT'] ?? $hm_platform_xray_start_time,
 		'end_time'   => microtime( true ),
 		'user'       => $user,
 		'service'    => [
@@ -483,6 +485,7 @@ function get_end_trace() : array {
 
 	$annotations = [
 		'memoryUsage' => memory_get_peak_usage() / 1048576, // Convert bytes to mb.
+		'fpmQueueTime' => $_SERVER['REQUEST_TIME_FLOAT'] - $_SERVER['NGINX_REQUEST_TIME'],
 	];
 
 	$trace['metadata'] = redact_metadata( $metadata );

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -405,9 +405,14 @@ function get_in_progress_trace() : array {
 		'response' => [],
 	];
 	$trace['metadata'] = redact_metadata( $metadata );
-	$trace['annotations'] = [
-		'fpmQueueTime' => $_SERVER['REQUEST_TIME_FLOAT'] - $_SERVER['NGINX_REQUEST_TIME'],
-	];
+
+	$annotations = [];
+
+	if ( isset( $_SERVER['REQUEST_TIME_FLOAT'] ) && isset( $_SERVER['NGINX_REQUEST_TIME'] ) ) {
+		$annotations['fpmQueueTime'] = $_SERVER['REQUEST_TIME_FLOAT'] - $_SERVER['NGINX_REQUEST_TIME'];
+	}
+	$trace['annotations'] = $annotations;
+
 	return $trace;
 }
 
@@ -485,8 +490,11 @@ function get_end_trace() : array {
 
 	$annotations = [
 		'memoryUsage' => memory_get_peak_usage() / 1048576, // Convert bytes to mb.
-		'fpmQueueTime' => $_SERVER['REQUEST_TIME_FLOAT'] - $_SERVER['NGINX_REQUEST_TIME'],
 	];
+
+	if ( isset( $_SERVER['REQUEST_TIME_FLOAT'] ) && isset( $_SERVER['NGINX_REQUEST_TIME'] ) ) {
+		$annotations['fpmQueueTime'] = $_SERVER['REQUEST_TIME_FLOAT'] - $_SERVER['NGINX_REQUEST_TIME'];
+	}
 
 	$trace['metadata'] = redact_metadata( $metadata );
 	$trace['annotations'] = $annotations;


### PR DESCRIPTION
By using timings from the request start from PHP we can get a more accurate picture of the PHP request time. We can also use the NGINX request start time (custom header we set in nginx) to calculate how long the request has had been waiting before PHP started processing it.

This will lead to a more accurate (but increased) measure of PHP processing / responce times.
