### PR TITLE
Include user agent in Xray traces

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -394,6 +394,7 @@ function get_in_progress_trace() : array {
 				'method'    => $_SERVER['REQUEST_METHOD'],
 				'url'       => ( empty( $_SERVER['HTTPS'] ) ? 'http' : 'https' ) . '://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'],
 				'client_ip' => $_SERVER['REMOTE_ADDR'],
+				'user_agent' => $_SERVER['HTTP_USER_AGENT'],
 			],
 		],
 		'in_progress' => true,
@@ -464,6 +465,7 @@ function get_end_trace() : array {
 				'method'    => $_SERVER['REQUEST_METHOD'],
 				'url'       => ( empty( $_SERVER['HTTPS'] ) ? 'http' : 'https' ) . '://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'],
 				'client_ip' => $_SERVER['REMOTE_ADDR'],
+				'user_agent' => $_SERVER['HTTP_USER_AGENT'],
 			],
 			'response' => [
 				'status' => http_response_code(),


### PR DESCRIPTION
This is part of the document spec: https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html#api-segmentdocuments-http

Fixes https://github.com/humanmade/vantage-backend/issues/1855
