### PR TITLE
Redact pass1 and pass2 in X-Ray metadata

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -999,6 +999,8 @@ function redact_metadata( $metadata ) {
 	$redact_keys_required = [
 		'$_POST' => [
 			'pwd',
+			'pass1',
+			'pass2',
 		],
 	];
 


### PR DESCRIPTION
Adds `pass1` and `pass2` to the metadata redaction list because they are used during WordPress password resets.

Fixes https://github.com/humanmade/product-dev/issues/1756