### PR TITLE
Fix unbounded memory growth of $hm_platform_xray_errors under CLI

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -133,6 +133,16 @@ function on_shutdown() {
  * @return boolean
  */
 function error_handler( int $errno, string $errstr, string $errfile = null, int $errline = null ) : bool {
+	// Avoid unbounded growth of $hm_platform_xray_errors during long-running
+	// CLI processes (e.g. a `wp elasticpress index` run that can take hours).
+	// There's no request boundary to flush the trace at until the whole CLI
+	// command finishes, so every error/warning would otherwise accumulate for
+	// the life of the process. Query Monitor bails out under CLI for the
+	// same reason (see query-monitor.php's `php_sapi_name() === 'cli'` check).
+	if ( 'cli' === php_sapi_name() ) {
+		return false;
+	}
+
 	global $hm_platform_xray_errors;
 
 	$hm_platform_xray_errors[] = compact( 'errno', 'errstr', 'errfile', 'errline' );


### PR DESCRIPTION
1. `error_handler()` appends every PHP error/warning to `$GLOBALS['hm_platform_xray_errors']`, unbounded, and that array is only flushed once — at process shutdown.
2. Fine for a normal request; fatal for long-running WP-CLI commands (e.g. a multi-hour `wp elasticpress index`), where the process doesn't "end" until the whole command finishes — memory grows for the entire run with no PHP fatal ever logged.
3. Query Monitor already guards against this exact scenario (`query-monitor.php`, `php_sapi_name() === 'cli'`); this plugin has no equivalent guard.
4. Reproduced locally: memory climbed from ~125MB to a 1GiB container ceiling in under 3 minutes indexing a ~26,500-post site. Matches a staging failure pattern (same sync died at three different offsets across three attempts).
5. Differential test confirmed the array as the dominant cause: clearing it every batch cut growth from ~12MB/s to ~2MB/s (~6-7x). The fix — skip appending under CLI — was verified the same way.
6. Closes #119.
